### PR TITLE
1.x - update constraints to support php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
         "email": "thomas@lekoala.be"
     }],
     "require": {
-        "php": "~7",
+        "php": ">7.2",
         "silverstripe/framework": "^4.1",
-        "tuupola/base62": "^0.10.0",
+        "tuupola/base62": "^2.0",
         "paragonie/sodium_compat": "^1.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "squizlabs/php_codesniffer": "^2.3"
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {
@@ -40,5 +40,11 @@
         "test": "phpunit -v"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,14 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
-    <testsuite name="travistestmodule">
-        <directory>tests/</directory>
-    </testsuite>
-
-    <file>code</file>
-    <file>tests</file>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="travistestmodule">
+    <directory>tests/</directory>
+  </testsuite>
 </phpunit>


### PR DESCRIPTION
> NOTE: Current version of this module has incompatibilities for composite fields with branch 2. Plan to rotate your values or keep using previous version.
> NOTE: Branch 2 of this module is not compatible with previous versions. Please use branch 1 if you need the previous encryption system.

I need to stick for a while with branch 1 because of legacy data and also upgrade to php8 at the same time. This fix dependency constraints and phpunit config for being comply.